### PR TITLE
Avoid deletion of a pending creation

### DIFF
--- a/fh-ios-sdk/Sync/FHSyncDataset.m
+++ b/fh-ios-sdk/Sync/FHSyncDataset.m
@@ -731,7 +731,8 @@ static NSString *const kUIDMapping = @"uidMapping";
     if (nil != deleted) {
         [deleted enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
             NSMutableArray* history = self.changeHistory[key];
-            if(history) {
+            FHSyncPendingDataRecord* pendingRecord = self.pendingDataRecords[key];
+            if(history && [pendingRecord.action isEqualToString:@"create"]) {
                 DLog(@"ignore delete with key %@ as it's outdated", key);
             } else {
                 [self.dataRecords removeObjectForKey:key];

--- a/fh-ios-sdk/Sync/FHSyncDataset.m
+++ b/fh-ios-sdk/Sync/FHSyncDataset.m
@@ -316,7 +316,7 @@ static NSString *const kUIDMapping = @"uidMapping";
     [self saveToFile:nil];
     [FHSyncUtils doNotifyWithDataId:self.datasetId
                              config:self.syncConfig
-                                uid:obj.uid
+                                   uid:obj.uid
                                code:LOCAL_UPDATE_APPLIED_MESSAGE
                             message:obj.action];
 }
@@ -465,7 +465,7 @@ static NSString *const kUIDMapping = @"uidMapping";
     self.syncLoopStart = [NSDate date];
     [FHSyncUtils doNotifyWithDataId:self.datasetId
                              config:self.syncConfig
-                                uid:NULL
+                                uid:NULL   
                                code:SYNC_STARTED_MESSAGE
                             message:NULL];
     if (![FH isOnline]) {
@@ -730,9 +730,9 @@ static NSString *const kUIDMapping = @"uidMapping";
     NSDictionary *deleted = resData[@"delete"];
     if (nil != deleted) {
         [deleted enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-            NSMutableArray* history = [self.changeHistory objectForKey:key];
-            if(history && [history containsObject:obj[@"hash"]]){
-                DLog(@"ignore delete with hash %@ as it's outdated", obj[@"hash"]);
+            NSMutableArray* history = self.changeHistory[key];
+            if(history) {
+                DLog(@"ignore delete with key %@ as it's outdated", key);
             } else {
                 [self.dataRecords removeObjectForKey:key];
                 [FHSyncUtils doNotifyWithDataId:self.datasetId


### PR DESCRIPTION
@wei-lee  
This is a fix for bug 6 as described by @cianclarke
When receiving the first syncRecords, check the delete is not in history. the check was there but the additional AND condition was wrong as for a deletion we don't get values but just keys.
